### PR TITLE
Fix: Ensure menubar and logo are visible and anchor floating text

### DIFF
--- a/hydrocav_website_manus/css/modules/layout.scss
+++ b/hydrocav_website_manus/css/modules/layout.scss
@@ -1,5 +1,5 @@
 /* Navigation */
-.navbar {
+.site-header {
   position: fixed;
   top: 0;
   left: 0;
@@ -10,13 +10,13 @@
   transition: all 0.3s ease;
 }
 
-.navbar.scrolled {
+.site-header.scrolled {
   background-color: rgba(255, 255, 255, 0.95);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   padding: 10px 0;
 }
 
-.navbar-container {
+.site-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -30,7 +30,7 @@
   transition: color 0.3s ease;
 }
 
-.navbar.scrolled .logo {
+.site-header.scrolled .logo {
   color: var(--primary-color);
 }
 
@@ -52,7 +52,7 @@
   position: relative;
 }
 
-.navbar.scrolled .nav-links a {
+.site-header.scrolled .nav-links a {
   color: var(--dark-color);
 }
 

--- a/hydrocav_website_manus/index.html
+++ b/hydrocav_website_manus/index.html
@@ -58,7 +58,7 @@
                     <picture>
                         <source data-srcset="/images/company-overview.avif" type="image/avif">
                         <source data-srcset="/images/company-overview.webp" type="image/webp">
-                        <img src="#" data-src="/images/company-overview.jpg" alt="Advanced HydroCav water treatment system component, illustrating the technology." class="parallax-image img-hover-lift" loading="lazy">
+                        <img src="#" data-src="/images/company-overview.jpg" alt="Advanced HydroCav water treatment system component, illustrating the technology." class="img-hover-lift" loading="lazy">
                     </picture>
                 </div>
             </div>


### PR DESCRIPTION
- I renamed .navbar to .site-header in CSS to match HTML, fixing visibility of the menu bar and logo.
- I addressed a floating text block issue in the About section by temporarily removing the 'parallax-image' class from the image in that section. This prevents the parallax script from transforming the image in a way that made the adjacent text appear unanchored.